### PR TITLE
Update Lambda Runtime to AmazonLinux2

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -91,7 +91,7 @@ export class ServerlessApi extends cdk.Construct {
     this.vpc = props.vpc;
 
     this.handler = props.handler ?? new lambda.Function(this, 'handler', {
-      runtime: lambda.Runtime.PROVIDED,
+      runtime: lambda.Runtime.PROVIDED_AL2,
       handler: 'public/index.php',
       layers: [
         lambda.LayerVersion.fromLayerVersionArn(this, 'BrefPHPLayer', props.brefLayerVersion),


### PR DESCRIPTION
I fixed lambda runtime execution error below

```
/opt/bin/php: error while loading shared libraries: libncurses.so.6: cannot open shared object file: No such file or directory
```

ref. https://stackoverflow.com/questions/67059259/error-libncurses-so-6-when-using-bref-lambda-custom-runtime-with-aws-cdk
