### PR TITLE
fix: use Credentials.fromSecret to avoid resolution error

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -21,7 +21,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "2.18.0",
+      "version": "2.29.1",
       "type": "build"
     },
     {
@@ -101,7 +101,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "^2.18.0",
+      "version": "^2.29.1",
       "type": "peer"
     },
     {

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -7,7 +7,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   authorName: 'Pahud Hsieh',
   authorEmail: 'hunhsieh@amazon.com',
   name: PROJECT_NAME,
-  cdkVersion: '2.18.0',
+  cdkVersion: '2.29.1',
   description: PROJECT_DESCRIPTION,
   repository: 'https://github.com/aws-samples/cdk-serverless-lamp.git',
   defaultReleaseBranch: 'main',

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/node": "^14",
     "@typescript-eslint/eslint-plugin": "^5",
     "@typescript-eslint/parser": "^5",
-    "aws-cdk-lib": "2.18.0",
+    "aws-cdk-lib": "2.29.1",
     "constructs": "10.0.5",
     "eslint": "^8",
     "eslint-import-resolver-node": "^0.3.6",
@@ -65,7 +65,7 @@
     "typescript": "^4.7.4"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.18.0",
+    "aws-cdk-lib": "^2.29.1",
     "constructs": "^10.0.5"
   },
   "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -242,10 +242,7 @@ export class DatabaseCluster extends Construct {
         instanceType: props.instanceType ?? new ec2.InstanceType('t3.medium'),
         securityGroups: [dbConnectionGroup],
       },
-      credentials: {
-        username: masterUserSecret.secretValueFromJson('username').toString(),
-        password: masterUserSecret.secretValueFromJson('password'),
-      },
+      credentials: rds.Credentials.fromSecret(masterUserSecret),
       instances: props.instanceCapacity,
       removalPolicy: RemovalPolicy.DESTROY,
     });

--- a/test/__snapshots__/integ.api.test.ts.snap
+++ b/test/__snapshots__/integ.api.test.ts.snap
@@ -276,6 +276,18 @@ Object {
       "Type": "AWS::SecretsManager::Secret",
       "UpdateReplacePolicy": "Delete",
     },
+    "DatabaseClusterDbMasterSecretAttachment4F388165": Object {
+      "Properties": Object {
+        "SecretId": Object {
+          "Ref": "DatabaseClusterDbMasterSecret98DF2329",
+        },
+        "TargetId": Object {
+          "Ref": "DatabaseClusterDBCluster27F7FF5A",
+        },
+        "TargetType": "AWS::RDS::DBCluster",
+      },
+      "Type": "AWS::SecretsManager::SecretTargetAttachment",
+    },
     "DatabaseClusterRdsProxyRole9B27D8A3": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1176,19 +1176,19 @@ at-least-node@^1.0.0:
   resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
   integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
-aws-cdk-lib@2.18.0:
-  version "2.18.0"
-  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.18.0.tgz#a130edf9d90ec166d5c0f14d275ab49cbbe75261"
-  integrity sha512-4XpEqRgKSzDmcpeNGRqRlnWEltnt5+NoHWKpQDHUsAmyJ2QNQ5dYxVLIReaGiE9H8zS0rlpp3exuDEy0UgKj2Q==
+aws-cdk-lib@2.29.1:
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.29.1.tgz#3a7bfb03f988c37c9ccd7db454bd66ffce427d14"
+  integrity sha512-tmWhsmSvNrJD9/SFAD0The7hON3VYUcFchKnjPg4vwvY89XzZv76IB24KLy3XoXF33WYvCUzDQPO/bCZQBF4LA==
   dependencies:
     "@balena/dockerignore" "^1.0.2"
     case "1.6.3"
     fs-extra "^9.1.0"
     ignore "^5.2.0"
-    jsonschema "^1.4.0"
+    jsonschema "^1.4.1"
     minimatch "^3.1.2"
     punycode "^2.1.1"
-    semver "^7.3.5"
+    semver "^7.3.7"
     yaml "1.10.2"
 
 babel-jest@^27.5.1:
@@ -3932,7 +3932,7 @@ jsonparse@^1.2.0, jsonparse@^1.3.1:
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
   integrity sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==
 
-jsonschema@^1.4.0:
+jsonschema@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.4.1.tgz#cc4c3f0077fb4542982973d8a083b6b34f482dab"
   integrity sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==


### PR DESCRIPTION
Newest version of AWS CDK throws an exception if secretValueFromJson is called without calling unsafeUnwrap.

This PR has a desirable side effect IMO which is to create a secret target attachment on the credential secret.

Blocked by #617.